### PR TITLE
block the kernel from being updated in archlinux

### DIFF
--- a/headless/deps/archlinux_deps.sh
+++ b/headless/deps/archlinux_deps.sh
@@ -2,3 +2,10 @@
 pacman -Sy --noconfirm
 pacman -S ruby git puppet --noconfirm
 pacman -S acl --noconfirm
+
+# Make sure the kernel is not upgraded on 'pacman -Syu' because otherwise we'd need to reboot
+# yet again before docker will work inside the virtualized guest due to the right veth kernel module 
+# not being able to be loaded.  Workaround for:
+# docker: Error response from daemon: failed to create endpoint ... on network bridge: 
+# failed to add the host (...) <=> sandbox (...) pair interfaces: operation not supported.
+grep -q "IgnorePkg = linux" "/etc/pacman.conf" || sed -i '/\[options\]/a IgnorePkg = linux' /etc/pacman.conf 


### PR DESCRIPTION
instead the base image should contain an up to date kernel or this box
should be packaged again and be used as the base box for future boots
